### PR TITLE
Demo opens the conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ name.
   is none; Step 7 is "Preview, then wait for yes" with preview-run, which
   prices nothing; cancel-run yields no report and counts no audit. The
   wallet, quote and credit-request tools are gone.
+- The demo opens every first conversation: `run-demo-audit` before
+  `get-plan`, a demo audit of a fictional neobank support bot (Kestrel Bank
+  Assistant, Grade C), read out as the grade, three impact cards, then "Ready
+  to test yours?"; skipped when the user opens by naming their own agent.
 
 ## 0.2.10 (2026-09-04)
 

--- a/plugin/skills/ifixai/SKILL.md
+++ b/plugin/skills/ifixai/SKILL.md
@@ -17,20 +17,26 @@ confirm it plainly, connect the endpoint, explain the result.
 **Every path needs a reachable HTTP endpoint** (us on paid, their machine on
 free). No endpoint, no audit: say so and stop.
 
-## Before anything: the demo works without an account
+## Before anything: the demo opens the conversation
 
 `run-demo-audit` and `list-inspections` answer signed-out; every other tool
 raises a sign-in prompt in the chat, where the account is also created.
 
-For an exploring or signed-out user, lead with `run-demo-audit`: a real frozen
-audit of **Riverline Support**, our demo refund bot (Grade D). Show the grade
-and open findings; locked rows unlock after sign-in. Always say it is our demo
-bot. Then offer the next step: the same audit on their agent, where sign-in
-happens.
+For every user who has not run an audit in this conversation, call
+`run-demo-audit` first, before discovery and before `get-plan`: a demo audit
+of a fictional neobank support bot, **Kestrel Bank Assistant** (Grade C, the
+50 open-source checks). Present it in this order: the grade and counts in one
+line; the three impact cards, each as one sentence plus its proof reply; then
+the line
+"This is iFixAi, and this is how we audit an agent. Ready to test yours?"
+Only after a yes does the normal flow start (Step 0, `get-plan`, discovery).
+Skip the demo when the user opens by naming their own agent or asking for a
+specific audit. Always say it is a demo of a fictional bot; locked rows unlock
+after sign-in.
 
 ## Step 0: which plan
 
-`get-plan` first (signed-out it raises the sign-in prompt, fine if their own
+`get-plan` next (signed-out it raises the sign-in prompt, fine if their own
 audit is what they asked for). `free` = runs on their machine, Step 0a then the
 normal flow. `paid` = we run it, on a package: `get-plan` names it, its
 inspection count, judges included, agents and seats


### PR DESCRIPTION
Guide leads every first conversation with the demo audit, then asks to test theirs. Replaces #6, which GitHub closed when its base merged.