### PR TITLE
Judges are not user-picked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ name.
 - The self-judging note applies to the free plan, where the user supplies the
   judge key.
 - Fixture authoring no longer points at files outside the published package.
+- Dropped the coverage caveat: checks that do not dial the endpoint grade the
+  setup we read and authored, so calling them unreached was misleading.
 
 ## 0.3.1 (2026-09-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ name.
 - Fixture authoring no longer points at files outside the published package.
 - Dropped the coverage caveat: checks that do not dial the endpoint grade the
   setup we read and authored, so calling them unreached was misleading.
+- Privacy: the report no longer names the judge, so the processor table says
+  iFixAi selects the judges rather than promising they are named.
 
 ## 0.3.1 (2026-09-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 Versions match `plugin/.claude-plugin/plugin.json` and the git tag of the same
 name.
 
+## 0.3.2 (2026-09-07)
+
+- The judges are not the user's to pick: the package's panel grades, the
+  preview says how many, and a run that fails on iFixAi's side says so in one
+  sentence and counts no audit.
+- The self-judging note applies to the free plan, where the user supplies the
+  judge key.
+- Fixture authoring no longer points at files outside the published package.
+
 ## 0.3.1 (2026-09-05)
 
 - Hosted sandbox: the operator points the test copy's tools at the

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -86,7 +86,7 @@
 <table>
   <thead><tr><th>Processor</th><th>Receives</th><th>Purpose</th></tr></thead>
   <tbody>
-    <tr><td>OpenRouter</td><td>Inspection prompts and your agent's replies</td><td>Grading. Routed to the judge model named in your report.</td></tr>
+    <tr><td>OpenRouter</td><td>Inspection prompts and your agent's replies</td><td>Grading. Routed to the judge models iFixAi selects for your plan.</td></tr>
     <tr><td>Supabase</td><td>Account, workspace and run records</td><td>Authentication and database hosting.</td></tr>
     <tr><td>Manufact (mcp-use)</td><td>Connector traffic in transit</td><td>Hosting the MCP server.</td></tr>
     <tr><td>Resend</td><td>Your email address</td><td>Sign-in and service email.</td></tr>

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ifixai",
   "displayName": "iFixAi",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Third-party auditing for AI agents. Run by a human or by the agent itself, to answer the most crucial question in the AI Agent Economy. Is the agent doing its actual job?",
   "author": {
     "name": "iFixAi",

--- a/plugin/skills/ifixai/SKILL.md
+++ b/plugin/skills/ifixai/SKILL.md
@@ -262,7 +262,7 @@ sends reach iFixAi.
 `preview-run` before starting; it prices nothing. Read `coverage.warning`
 aloud when set. It also says which requested inspections are outside the
 package (drop them, or `request-access` for the package that has them),
-whether the judge count fits the package, and audits left this month.
+how many judges the package grades with, and audits left this month.
 **Default to `suite: "all"`** when the package has it: gating inspections not
 run score as failures, so smaller selections are capped and cannot pass; they
 are a quick look, never a verdict. A run is one of the package's monthly
@@ -275,8 +275,10 @@ the same test-target question as in Step 0a and pass `targetIsSandboxed`; a no
 is refused before anything starts: go to Step 0b.
 `run-inspection` returns a run id; the audit continues server-side, minutes to
 tens of minutes. Poll `get-run` without busy-looping. A refusal names the way
-out: no package, a selection outside it, too many judges, or the month's
-audits used up (with the reset date); each names `request-access`. `cancel-run`
+out: no package, a selection outside it, or the month's audits used up (with
+the reset date); each names `request-access`. The judges are never the user's
+to pick: the package's panel grades, and a run that fails on iFixAi's side
+says so in one sentence and counts no audit. `cancel-run`
 stops the run for good: it yields no report and does not count as an audit.
 Tell them before cancelling.
 
@@ -303,8 +305,9 @@ recorded none; never read that as zero.
 ## Honest constraints
 
 - A clean result is a diagnostic, not a certification or clearance to deploy.
-- The judge is iFixAi's model; if their agent runs the same model the run is
-  effectively self-judged and nothing flags it. Say so if they name theirs.
+- On the free plan the judge runs on their key: if their agent runs the same
+  model the run is effectively self-judged and nothing flags it. Say so if
+  they name theirs.
 - Roughly half the roster never dials a plain HTTP agent and reads
   inconclusive; `coverage` on the preview shows how much a selection reaches.
 - The synthetic org is fictional: the audit probes whether claimed role

--- a/plugin/skills/ifixai/SKILL.md
+++ b/plugin/skills/ifixai/SKILL.md
@@ -190,11 +190,10 @@ name the source under each heading:
 
 Where the repo says nothing, write "not stated" under the heading rather
 than filling it in. Same repo, same description, same fixture: this is the
-shape author-fixture is trained on (`ifixai/fixtures/reference/description.md`
-in the ifixai repo is the worked example).
+shape author-fixture is trained on.
 
-Free plan: write the fixture yourself from the same description, in the
-shape of `ifixai/fixtures/reference/fixture.yaml`, then `validate` locally.
+Free plan: write the fixture yourself from the same description, then
+`validate` locally.
 The rules that keep it repeatable:
 
 - roles: approving role first, the rest alphabetical; one role in the repo

--- a/plugin/skills/ifixai/SKILL.md
+++ b/plugin/skills/ifixai/SKILL.md
@@ -307,8 +307,6 @@ recorded none; never read that as zero.
 - On the free plan the judge runs on their key: if their agent runs the same
   model the run is effectively self-judged and nothing flags it. Say so if
   they name theirs.
-- Roughly half the roster never dials a plain HTTP agent and reads
-  inconclusive; `coverage` on the preview shows how much a selection reaches.
 - The synthetic org is fictional: the audit probes whether claimed role
   boundaries actually hold.
 - Content leaves their machine (Step 4): description, probes, replies all


### PR DESCRIPTION
The operator guide no longer offers a judge choice on the paid plan. The self-judging note now applies to the free plan only.